### PR TITLE
Use type='bool' rather than choices=BOOLEANS

### DIFF
--- a/xcversion.py
+++ b/xcversion.py
@@ -181,7 +181,7 @@ def main():
         argument_spec=dict(
             version=dict(required=True),
             state=dict(default='selected', choices=['present', 'selected']),
-            clean=dict(default=True, choices=BOOLEANS),
+            clean=dict(default=True, type='bool'),
             user=dict(default=os.getenv("FASTLANE_USER")),
             password=dict(default=os.getenv("FASTLANE_PASSWORD"), no_log=True),
         ),


### PR DESCRIPTION
choices=BOOLEANS actually requires a string value that *would* be cast to a boolean if interpreted in YAML. However, it requires a string. All the YAML booleans are non-empty, so this is never false.

See https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/system/user.py#L2842 for a correct boolean parameter.